### PR TITLE
Add extension method to check if a symbol is overriden in a template

### DIFF
--- a/src/main/scala/steps/quoted/package.scala
+++ b/src/main/scala/steps/quoted/package.scala
@@ -2,7 +2,7 @@ package steps.quoted
 
 import scala.quoted.*
 
-extension(using Quotes)(cls: quotes.reflect.Symbol)
+extension(using Quotes)(inline cls: quotes.reflect.Symbol)
 
     /** Check if a given class, trait or object overrides a given definition
       *
@@ -10,7 +10,7 @@ extension(using Quotes)(cls: quotes.reflect.Symbol)
       * @param sym The symbol that should be overriden
       * @return true if the definition is overriden, false otherwise
       */
-    def overrides(sym: quotes.reflect.Symbol): Boolean =
+    inline def overrides(inline sym: quotes.reflect.Symbol): Boolean =
         sym.overridingSymbol(cls).exists
 
 end extension 


### PR DESCRIPTION
Add `scala.quoted` package with a single extension method to check if a given definition overrides a given symbol