### PR TITLE
add Result.task as a useful optimisation

### DIFF
--- a/src/main/scala/steps/result/package.scala
+++ b/src/main/scala/steps/result/package.scala
@@ -444,6 +444,11 @@ object Result:
     */
   val empty: Result[EmptyTuple, Nothing] = Ok(EmptyTuple)
 
+  /** Constant unit value for use with [[Result.task]]
+    * @group construct
+    */
+  val done: Result[Unit, Nothing] = Ok(())
+
   /** Construct a `Result[T, E]` based on the condition given in `test`.
     * If the `test` succeeds (i.e. `test` is `true`), [[Ok]] with `ifTrue` is returned;
     * otherwise, return [[Err]] with `ifFalse`.
@@ -471,6 +476,18 @@ object Result:
       inline body: boundary.Label[Result[T, E]] ?=> T
   ): Result[T, E] = eval(body)
 
+  /** Evaluates `body`, if it succeeds without fail then return [[Result.done]].
+    *
+    * Within `body`:
+    *   - [[eval.ok]] can be used to unwrap [[Result]] values, with the body
+    *     short-circuiting back with the error.
+    *   - [[eval.raise]] can be used to quickly short-circuit with an error.
+    * @group eval
+    */
+  inline def task[E](
+      inline body: boundary.Label[Result[Unit, E]] ?=> Unit
+  ): Result[Unit, E] = eval.task(body)
+
   /** Operations that are valid under a [[Result.apply]] scope.
     * @group eval
     * @see
@@ -482,6 +499,14 @@ object Result:
         inline body: boundary.Label[Result[T, E]] ?=> T
     ): Result[T, E] =
       boundary(Ok(body))
+
+    /** Similar to [[Result.task]]. */
+    inline def task[E](
+        inline body: boundary.Label[Result[Unit, E]] ?=> Unit
+    ): Result[Unit, E] =
+      boundary:
+        body
+        Result.done
 
     /** Short-circuits the current `body` under [[Result$.apply Result.apply]]
       * with the given error.
@@ -632,6 +657,33 @@ object Result:
       inline def ok: T = r match
         case Ok(value)   => value
         case err: Err[E] => breakErr(err)
+
+    extension [E](using
+        @implicitNotFound(
+          "`.check` cannot be used outside of the `Result.task` scope."
+        )
+        label: boundary.Label[Err[E]]
+      )(inline r: into[Result[Unit, E]])
+
+      /** Checks that the result is not [[Err]], if so return normally, else short-circuit
+        * the current `body` under [[Result$.task Result.task]] with the given
+        * error if the result is an [[Err]].
+        *  ```
+        *  val ok: Result[Unit, Nothing] = Result.done
+        *  val err: Result[Int, String] = Err("fail!")
+        *
+        *  val compute = Result.task:
+        *    ok.check    // ok, continues
+        *    err.ok      // error, immediately sets compute to Err("fail")
+        *    println(23) // not evaluated
+        *  ```
+        * @group eval
+        * @see
+        *   [[task]] and [[raise]].
+        */
+      inline def check: Unit = r match
+        case err: Err[E] => breakErr(err)
+        case _ => ()
 
     // Separate design of ok that does this conversion hackery just to let you pass label explicitly,
     // it seems better to work with `jumpTo` instead that can co-erce the type inference without this extra conversion type.

--- a/src/main/scala/steps/result/package.scala
+++ b/src/main/scala/steps/result/package.scala
@@ -670,11 +670,11 @@ object Result:
         * error if the result is an [[Err]].
         *  ```
         *  val ok: Result[Unit, Nothing] = Result.done
-        *  val err: Result[Int, String] = Err("fail!")
+        *  val err: Result[Unit, String] = Err("fail!")
         *
         *  val compute = Result.task:
         *    ok.check    // ok, continues
-        *    err.ok      // error, immediately sets compute to Err("fail")
+        *    err.check   // error, immediately sets compute to Err("fail")
         *    println(23) // not evaluated
         *  ```
         * @group eval

--- a/src/test/scala/steps/result/ResultTask.scala
+++ b/src/test/scala/steps/result/ResultTask.scala
@@ -1,0 +1,120 @@
+package steps.result
+
+import steps.result.Result.eval.{check, ok, raise}
+
+// test demonstration that Result.task is a useful optimisation for side-effecting operations
+// such as consuming a mutable stream (i.e. on each pull we can do something useful, or error)
+
+class ResultTaskTest extends munit.FunSuite {
+
+  test("check that str is all same (Result.apply, ok)"):
+    val c = Checker("aaa")
+    assertEquals(c.isAllX('a'), Result.done)
+
+  test("check that str is all same (Result.task, check)"):
+    val c = Checker("aaa")
+    assertEquals(c.isAllY('a'), Result.done)
+
+  test("check fail that str is all same (Result.apply, ok)"):
+    val c = Checker("abc")
+    assertEquals(c.isAllX('a'), Result.Err(CheckErr("expected 'a'", 1)))
+
+  test("check fail that str is all same (Result.task, check)"):
+    val c = Checker("abc")
+    assertEquals(c.isAllY('a'), Result.Err(CheckErr("expected 'a'", 1)))
+
+}
+
+case class CheckErr(msg: String, idx: Int)
+
+/**Class to parse a string with a simple validation
+ *
+ * CFR decompilation output, observe that `isAllY` is much more compact and does not
+ * allocate `new Result.Ok`:
+ * ```java
+ * public class Checker
+ * extends CharStream {
+ *     public Checker(String s) {
+ *         super(s);
+ *     }
+ *
+ *     public Result<BoxedUnit, CheckErr> isAllX(char x) {
+ *         while (!this.isEOF()) {
+ *             Result<BoxedUnit, CheckErr> result = this.expectChar(x);
+ *             if (result instanceof Result.Ok) {
+ *                 Result.Ok ok = (Result.Ok)result;
+ *                 Result.Ok ok2 = Result.Ok$.MODULE$.unapply(ok);
+ *                 BoxedUnit boxedUnit = (BoxedUnit)ok2._1();
+ *                 BoxedUnit boxedUnit2 = BoxedUnit.UNIT;
+ *                 BoxedUnit boxedUnit3 = boxedUnit;
+ *                 if (!(boxedUnit2 != null ? !boxedUnit2.equals(boxedUnit3) : boxedUnit3 != null)) {
+ *                     BoxedUnit value = boxedUnit;
+ *                     continue;
+ *                 }
+ *             }
+ *             if (result instanceof Result.Err) {
+ *                 Result.Err err;
+ *                 Result.Err err2 = err = (Result.Err)result;
+ *                 return err2;
+ *             }
+ *             throw new MatchError(result);
+ *         }
+ *         return Result.Ok$.MODULE$.apply((Object)BoxedUnit.UNIT);
+ *     }
+ *
+ *     public Result<BoxedUnit, CheckErr> isAllY(char y) {
+ *         while (!this.isEOF()) {
+ *             Result.Err err;
+ *             Result<BoxedUnit, CheckErr> result = this.expectChar(y);
+ *             if (!(result instanceof Result.Err)) continue;
+ *             Result.Err err2 = err = (Result.Err)result;
+ *             return err2;
+ *         }
+ *         return Result$.MODULE$.done();
+ *     }
+ *
+ *     public Result<BoxedUnit, CheckErr> expectChar(char c) {
+ *         if (this.currentChar() != c) {
+ *             return new Result.Err((Object)CheckErr$.MODULE$.apply("expected '" + c + "'", this.currentOffset()));
+ *         }
+ *         this.advance();
+ *         return Result$.MODULE$.done();
+ *     }
+ * }
+ * ```
+ */
+class Checker(s: String) extends CharStream(s):
+  /** using basic `apply` and `ok` */
+  def isAllX(x: Char): Result[Unit, CheckErr] =
+    Result:
+      while !isEOF do
+        expectChar(x).ok
+
+  /** optimised with `Result.task` and `check` */
+  def isAllY(y: Char): Result[Unit, CheckErr] =
+    Result.task:
+      while !isEOF do
+        expectChar(y).check
+
+  def expectChar(c: Char): Result[Unit, CheckErr] = Result.task:
+    if currentChar == c then
+      advance()
+    else
+      raise(CheckErr(s"expected '$c'", currentOffset))
+
+
+
+class CharStream(s: String):
+  private var currIdx: Int = -1
+  private var currChar: Char = -1.toChar
+  advance() // initialize
+  def currentChar: Char = currChar
+  def currentOffset: Int = currIdx
+  def isEOF: Boolean = currIdx >= s.length()
+  def advance(): Unit =
+    val i = currIdx + 1
+    if i < s.length() then
+      currChar = s(i)
+    else
+      currChar = '\u0000'
+    currIdx = i


### PR DESCRIPTION
if you have an algorithm where mostly you do some side effecting thing such as push to a builder and consume from a mutable stream, then mostly its the happy path of Unit and occasional failure. Model that usecase for optimal bytecode and reduced allocation