### PR TITLE
scalajs: add Scala.js cross-compilation support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ jobs:
   test:
     strategy:
       fail-fast: false
+      matrix:
+        platform: [JVM, JS]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -20,5 +22,9 @@ jobs:
         distribution: temurin
         java-version: 17
     - uses: sbt/setup-sbt@v1
+    - uses: actions/setup-node@v4
+      if: matrix.platform == 'JS'
+      with:
+        node-version: 22
     - name: Test
-      run: sbt test
+      run: sbt root${{ matrix.platform }}/test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ jobs:
           java-version: 17
           cache: sbt
       - uses: sbt/setup-sbt@v1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
       - run: sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -39,8 +39,8 @@ jobs:
       - uses: sbt/setup-sbt@v1
       - name: Build docs
         run: |
-          sbt doc
-          cp -rv target/scala-*/api api
+          sbt rootJVM/doc
+          cp -rv .jvm/target/scala-*/api api
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/build.sbt
+++ b/build.sbt
@@ -40,14 +40,15 @@ inThisBuild(
   )
 )
 
-lazy val root = project
+lazy val root = crossProject(JVMPlatform, JSPlatform)
+  .crossType(CrossType.Pure)
   .in(file("."))
   .settings(
     name := "steps",
     scalaVersion := scala3Version,
     libraryDependencies ++= Seq(
       // "org.scala-lang" %% "scala2-library-cc-tasty-experimental" % scala3Version,
-      "org.scalameta" %% "munit" % "0.7.29" % Test
+      "org.scalameta" %%% "munit" % "0.7.29" % Test
     ),
     scalacOptions ++= Seq(
       // "-Xprint:cc"
@@ -56,4 +57,7 @@ lazy val root = project
     Compile / doc / scalacOptions ++= Seq(
       "-groups"
     )
+  )
+  .jsSettings(
+    scalaJSUseMainModuleInitializer := false
   )

--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,7 @@
           # Equivalent to  inputs'.nixpkgs.legacyPackages.hello;
           # packages.default = pkgs.hello;
           devShells.default = pkgs.mkShell {
-            buildInputs = [ jre ] ++ scala-tools;
+            buildInputs = [ jre pkgs.nodejs ] ++ scala-tools;
           };
         };
       flake = {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,8 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.2")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.21.0")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
+// sbt-ci-release bundles an older JGit that does not support git worktrees.
+// Overriding to JGit 7+ fixes the NoWorkTreeException on project load.
+// Note: JGit 7+ requires Java 17+.
+libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit" % "7.0.0.202409031743-r"


### PR DESCRIPTION
## What

Adds Scala.js support to the `steps` library so that it publishes and tests on both JVM and JS platforms.

## Changes

### Build
- Convert `build.sbt` from a plain `project` to `crossProject(JVMPlatform, JSPlatform).crossType(CrossType.Pure)` using `sbt-scalajs` 1.21.0 and `sbt-scalajs-crossproject` 1.3.2
- Switch munit dependency to `%%%` so it resolves correctly on both platforms
- All existing tests pass on JS — no platform-split sources needed

### JGit / worktree fix
- `sbt-ci-release`'s bundled JGit < 7 throws `NoWorkTreeException` when run inside a git worktree (it mistakes the `.git` file for a bare repo)
- Fix: override JGit to `7.0.0.202409031743-r` in `project/plugins.sbt` — JGit 7 natively handles worktrees
- **Requires Java 17+** (already the project minimum)

### Nix flake
- Added `pkgs.nodejs` to `devShell` so the JS linker can run locally

### GitHub Actions
- **`ci.yml`**: matrix over `[JVM, JS]`; JS job installs Node 22 before running `rootJS/test`
- **`release.yml`**: installs Node 22 so Scala.js artifact can link during `sbt ci-release`
- **`static.yml`**: fix `sbt doc` → `sbt rootJVM/doc` and fix the output path to `.jvm/target/scala-*/api`
