### PR TITLE
scala-native: add Scala Native 0.5.11 cross-compilation support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [JVM, JS]
+        platform: [JVM, JS, Native]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -26,5 +26,8 @@ jobs:
       if: matrix.platform == 'JS'
       with:
         node-version: 22
+    - name: Install clang (Native)
+      if: matrix.platform == 'Native'
+      run: sudo apt-get update && sudo apt-get install -y clang libgc-dev
     - name: Test
       run: sbt root${{ matrix.platform }}/test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+      - name: Install clang (for Scala Native)
+        run: sudo apt-get update && sudo apt-get install -y clang libgc-dev
       - run: sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ inThisBuild(
   )
 )
 
-lazy val root = crossProject(JVMPlatform, JSPlatform)
+lazy val root = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .crossType(CrossType.Pure)
   .in(file("."))
   .settings(
@@ -48,7 +48,7 @@ lazy val root = crossProject(JVMPlatform, JSPlatform)
     scalaVersion := scala3Version,
     libraryDependencies ++= Seq(
       // "org.scala-lang" %% "scala2-library-cc-tasty-experimental" % scala3Version,
-      "org.scalameta" %%% "munit" % "0.7.29" % Test
+      "org.scalameta" %%% "munit" % "1.2.4" % Test
     ),
     scalacOptions ++= Seq(
       // "-Xprint:cc"
@@ -60,4 +60,9 @@ lazy val root = crossProject(JVMPlatform, JSPlatform)
   )
   .jsSettings(
     scalaJSUseMainModuleInitializer := false
+  )
+  .nativeSettings(
+    nativeConfig ~= {
+      _.withIncrementalCompilation(true)
+    }
   )

--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,7 @@
           # Equivalent to  inputs'.nixpkgs.legacyPackages.hello;
           # packages.default = pkgs.hello;
           devShells.default = pkgs.mkShell {
-            buildInputs = [ jre pkgs.nodejs ] ++ scala-tools;
+            buildInputs = [ jre pkgs.nodejs pkgs.clang pkgs.boehmgc ] ++ scala-tools;
           };
         };
       flake = {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,9 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.2")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.21.0")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.11")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
 // sbt-ci-release bundles an older JGit that does not support git worktrees.
 // Overriding to JGit 7+ fixes the NoWorkTreeException on project load.
 // Note: JGit 7+ requires Java 17+.


### PR DESCRIPTION
Builds on #35 (Scala.js support) to add Scala Native 0.5.11 as a third cross-compilation target.

## Changes

### Build
- Add `sbt-scala-native 0.5.11` and `sbt-scala-native-crossproject 1.3.2` to `project/plugins.sbt`
- Extend `crossProject` to include `NativePlatform` with incremental compilation enabled via `.nativeSettings`
- Upgrade munit to `1.2.4` — munit 0.7.x has no `native0.5` artifact

### GitHub Actions
- **`ci.yml`**: add `Native` to the platform matrix; install `clang` + `libgc-dev` for the Native job
- **`release.yml`**: install `clang` + `libgc-dev` so the Native artifact can link during `sbt ci-release`

### Nix flake
- Add `pkgs.clang` and `pkgs.boehmgc` to `devShell` buildInputs

## Testing
All 19 tests pass on all three platforms (JVM, JS, Native), including `AnyhowClone` which uses `Thread.currentThread().getStackTrace()`. Native tests verified both directly via `sbt rootNative/test` and through `nix develop`.
